### PR TITLE
interstitial step to get multiple tile maps

### DIFF
--- a/files/tasks.py
+++ b/files/tasks.py
@@ -25,7 +25,14 @@ def geojson_to_mbtile(user, files):
 def mbtile_upload(file_id):
     f = File.objects.get(pk=file_id)
     data = get_from_s3(f)
-    upload_shapefile(data, f"{f.locality.state.abbreviation.lower()}-precincts")
+    elections = f.statewide_elections.all()
+    for election in elections:
+        if (election.dem_property or election.rep_property):
+            upload_shapefile(
+                data,
+                f"{f.locality.state.abbreviation.lower()}"
+                "-{election.year}-{election.office_type}-precincts"
+            )
 
 
 geojson_to_mapbox = chain(geojson_to_mbtile.s(), mbtile_upload.s())

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -27,6 +27,7 @@ def mbtile_upload(file_id):
     data = get_from_s3(f)
     upload_shapefile(data, f"{f.locality.state.abbreviation.lower()}-precincts")
 
+
 @shared_task
 def mbtile_upload_by_year(file_id):
     f = File.objects.get(pk=file_id)

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -30,8 +30,7 @@ def mbtile_upload(file_id):
         if (election.dem_property or election.rep_property):
             upload_shapefile(
                 data,
-                f"{f.locality.state.abbreviation.lower()}"
-                "-{election.year}-{election.office_type}-precincts"
+                f"{f.locality.state.abbreviation.lower()}-{election.year}-precincts"
             )
 
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -25,6 +25,12 @@ def geojson_to_mbtile(user, files):
 def mbtile_upload(file_id):
     f = File.objects.get(pk=file_id)
     data = get_from_s3(f)
+    upload_shapefile(data, f"{f.locality.state.abbreviation.lower()}-precincts")
+
+@shared_task
+def mbtile_upload_by_year(file_id):
+    f = File.objects.get(pk=file_id)
+    data = get_from_s3(f)
     elections = f.statewide_elections.all()
     for election in elections:
         if (election.dem_property or election.rep_property):
@@ -35,7 +41,8 @@ def mbtile_upload(file_id):
 
 
 geojson_to_mapbox = chain(geojson_to_mbtile.s(), mbtile_upload.s())
+geojson_to_mapbox_by_year = chain(geojson_to_mbtile.s(), mbtile_upload_by_year.s())
 
 
 # add tasks here to expose in admin
-TASK_NAMES = ["zip_files", "to_geojson", "geojson_to_mapbox"]
+TASK_NAMES = ["zip_files", "to_geojson", "geojson_to_mapbox", "geojson_to_mapbox_by_year"]

--- a/raw_static/js/precinct-map.js
+++ b/raw_static/js/precinct-map.js
@@ -164,7 +164,7 @@ export default class PrecinctMap extends React.Component {
               tileJsonSource={{
                 type: "vector",
                 url:
-                  "mapbox://openprecincts." + this.props.stateFromPath + "-" + this.props.year + "-precincts",
+                  "mapbox://openprecincts." + this.props.stateFromPath + "-precincts",
               }}
             />
             <Source

--- a/raw_static/js/precinct-map.js
+++ b/raw_static/js/precinct-map.js
@@ -164,7 +164,7 @@ export default class PrecinctMap extends React.Component {
               tileJsonSource={{
                 type: "vector",
                 url:
-                  "mapbox://openprecincts." + this.props.stateFromPath + "-" + this.props.year + "-" + this.props.officeType + "-precincts",
+                  "mapbox://openprecincts." + this.props.stateFromPath + "-" + this.props.year + "-precincts",
               }}
             />
             <Source

--- a/raw_static/js/precinct-map.js
+++ b/raw_static/js/precinct-map.js
@@ -164,7 +164,7 @@ export default class PrecinctMap extends React.Component {
               tileJsonSource={{
                 type: "vector",
                 url:
-                  "mapbox://openprecincts." + this.props.stateFromPath + "-precincts",
+                  "mapbox://openprecincts." + this.props.stateFromPath + "-" + this.props.year + "-" + this.props.officeType + "-precincts",
               }}
             />
             <Source


### PR DESCRIPTION
this:
- adds a new parallel upload function that renames mbtiles files to include year

so we can 
- reupload tiles

and then eventually cut over to the new filename convention (which will come in in another PR)